### PR TITLE
get agent version in npm-3 safe way

### DIFF
--- a/bin/sl-run.js
+++ b/bin/sl-run.js
@@ -3,8 +3,7 @@
 var WebsocketChannel = require('strong-control-channel/ws-channel');
 var debug = require('debug')('strong-heroku-runner');
 var os = require('os');
-var agentVersion =
-  require('strong-supervisor/node_modules/strong-agent/package.json').version;
+var agentVersion = require('strong-supervisor/lib/agent')().version;
 var supervisorVersion = require('strong-supervisor/package.json').version;
 var version = require('../package.json').version;
 


### PR DESCRIPTION
Some versions of npm (3.x+) dedupe and flatten the deps at install time,
so strong-agent won't always be under strong-supervisor.